### PR TITLE
Allow creation of a flexvector sublist using flexvector->list

### DIFF
--- a/implementation/flexvectors-body2.scm
+++ b/implementation/flexvectors-body2.scm
@@ -369,9 +369,20 @@
       fv)
     (values left right)))
 
-(define (flexvector->list fv)
-  (assume (flexvector? fv))
-  (flexvector-fold-right (lambda (x y) (cons y x)) '() fv))
+(define flexvector->list
+  (case-lambda
+    ((fv)
+     (flexvector->list fv 0 (flexvector-length fv)))
+    ((fv start)
+     (flexvector->list fv start (flexvector-length fv)))
+    ((fv start end)
+     (if (< end start)
+       (error "invalid start/end specification")
+       (let lp ((acc '()) (idx (- end 1)))
+         (if (< idx start)
+           acc
+           (lp (cons (vector-ref (vec fv) idx) acc)
+               (- idx 1))))))))
 
 (define (reverse-flexvector->list fv . o)
   (assume (flexvector? fv))

--- a/implementation/tests.scm
+++ b/implementation/tests.scm
@@ -86,6 +86,9 @@
 (let ((fv (flexvector 10 20 30)))
   (test-equal "flexvector->vector" #(10 20 30) (flexvector->vector fv))
   (test-equal "flexvector->list" '(10 20 30) (flexvector->list fv))
+  (test-equal "flexvector->list sublist" '(10 20) (flexvector->list fv 0 2))
+  (test-equal "flexvector->list omitted end" '(20 30) (flexvector->list fv 1))
+  (test-equal "flexvector->list same index" '() (flexvector->list fv 1 1))
   (test-equal "reverse-flexvector->list" '(30 20 10) (reverse-flexvector->list fv))
   (test-equal "flexvector-copy" #t
     (let ((copy (flexvector-copy fv)))


### PR DESCRIPTION
See https://srfi-email.schemers.org/srfi-214/threads/2024/8/

Not sure what the design goals of the reference implementation are a more simple/readable variant would be something along the line of:

```scheme
(define flexvector->list
  (case-lambda
    ((fv)
     (flexvector->list fv 0 (flexvector-length fv)))
    ((fv start)
     (flexvector->list fv start (flexvector-length fv)))
    ((fv start end)
     (vector->list (vector-copy (vec fv) start end)))))
```